### PR TITLE
Fix: combine map (ugly fix)

### DIFF
--- a/src/AIAC/EventSys/Event.h
+++ b/src/AIAC/EventSys/Event.h
@@ -13,6 +13,7 @@ namespace AIAC
         None = 0,
         AppClose,
         SLAMMapLoaded, SLAMVocabularyLoaded, SLAMStartMapping, SLAMStopMapping,
+        SLAMCombineMapEvent,
         CameraCalibrationLoaded
         /* add types of events here */
     };

--- a/src/AIAC/EventSys/EventBus.h
+++ b/src/AIAC/EventSys/EventBus.h
@@ -32,6 +32,10 @@ namespace AIAC
                 auto& slamEvent = static_cast<SLAMStopMappingEvent&>(*event);
                 slamEvent.OnSLAMStopMapping();
             });
+            m_EventQueue.appendListener(EventType::SLAMCombineMapEvent, [](const EventPointer& event) {
+                auto& slamEvent = static_cast<SLAMCombineMapEvent&>(*event);
+                slamEvent.OnSLAMCombineMap();
+            });
             m_EventQueue.appendListener(EventType::CameraCalibrationLoaded, [](const EventPointer& event) {
                 auto& cameraEvent = static_cast<CameraCalibrationLoadedEvent&>(*event);
                 cameraEvent.OnCameraCalibrationFileLoaded();

--- a/src/AIAC/EventSys/SLAMEvent.cpp
+++ b/src/AIAC/EventSys/SLAMEvent.cpp
@@ -3,6 +3,7 @@
 #include "AIAC/EventSys/SLAMEvent.h"
 #include "AIAC/Application.h"
 #include <filesystem>
+#include <cstdlib>
 
 namespace AIAC
 {
@@ -123,5 +124,54 @@ namespace AIAC
             if(isReconstructed) AIAC_APP.GetLayer<AIAC::LayerModel>()->LoadScannedModel(recPlyPath);
             else AIAC_WARN("Reconstruction failed, skip loading the model");
         }
+    }
+
+    void SLAMCombineMapEvent::OnSLAMCombineMap()
+    {
+        if (m_OutputPath.empty()) {
+            auto basePathA = m_MapPathA.substr(0, m_MapPathA.find_last_of('.'));
+            auto filenameB = m_MapPathB.substr(m_MapPathB.find_last_of('/') + 1);
+            m_OutputPath = basePathA + "_combined_" + filenameB;
+        }
+
+        // FIXME: nasty workaround
+        string command = "tslam_combine_map ";
+        command += m_MapPathA + " " + m_MapPathB + " " + m_OutputPath;
+        std::system(command.c_str());
+
+        auto basePath = m_OutputPath.substr(0, m_OutputPath.find_last_of("."));
+        auto ymlTagMapPath = basePath + ".yml";
+        auto recPlyPath = basePath + ".ply";
+
+        /// FIXME: Some tag disappears after combining maps, don't know why
+//        AIAC_APP.GetLayer<LayerSlam>()->Slam.CombineMap(
+//                m_MapPathA, m_MapPathB, m_OutputPath,
+//                false, false, nullptr, m_OptimizeIterations);
+//
+//        AIAC_APP.GetLayer<LayerSlam>()->UpdateMap(m_OutputPath);
+//
+//        AIAC_APP.GetLayer<AIAC::LayerSlam>()->Slam.getMap()->saveToFile(ymlTagMapPath);
+//        if(AIAC_APP.GetLayer<AIAC::LayerSlam>()->Slam.getMap()->map_markers.size() == 0){
+//            AIAC_WARN("No tag in the map, skip rest of the process");
+//            return;
+//        }
+
+        // Reconstruct 3D
+        bool isReconstructed = AIAC_APP.GetLayer<AIAC::LayerSlam>()->Slam.Reconstruct3DModelAndExportPly(
+                ymlTagMapPath,
+                recPlyPath,
+                m_RadiusSearch,
+                m_CreaseAngleThreshold,
+                m_MinClusterSize,
+                m_AABBScaleFactor,
+                m_MaxPolyTagDist,
+                m_MaxPlnDist2Merge,
+                m_MaxPlnAngle2Merge,
+                m_EPS
+        );
+
+        // Load reconstructed 3D model
+        if(isReconstructed) AIAC_APP.GetLayer<AIAC::LayerModel>()->LoadScannedModel(recPlyPath);
+        else AIAC_WARN("Reconstruction failed, skip loading the model");
     }
 }

--- a/src/AIAC/EventSys/SLAMEvent.h
+++ b/src/AIAC/EventSys/SLAMEvent.h
@@ -85,4 +85,54 @@ namespace AIAC
         double m_MaxPlnAngle2Merge;
         double m_EPS;
     };
+
+    class SLAMCombineMapEvent : public Event
+    {
+    public:
+        // FIXME: This is a bit ugly, creating a struct for the two sets of parameters may be better?
+        explicit SLAMCombineMapEvent(
+                // Combine Map Parameters
+                std::string mapPathA,
+                std::string mapPathB,
+                std::string outputPath,
+                int optimizeIterations,
+
+                // Reconstruction Parameters
+                float radiusSearch,
+                double creaseAngleThreshold,
+                int minClusterSize,
+                double AABBScaleFactor,
+                double maxPolyTagDist,
+                double maxPlnDist2Merge,
+                double maxPlnAngle2Merge,
+                double EPS)
+
+                : Event(EventType::SLAMCombineMapEvent, EventCategory::EventCategorySLAM),
+                  m_MapPathA(std::move(mapPathA)), m_MapPathB(std::move(mapPathB)), m_OutputPath(std::move(outputPath)),
+                  m_OptimizeIterations(optimizeIterations),
+                  m_RadiusSearch(radiusSearch), m_CreaseAngleThreshold(creaseAngleThreshold),
+                  m_MinClusterSize(minClusterSize), m_AABBScaleFactor(AABBScaleFactor),
+                  m_MaxPolyTagDist(maxPolyTagDist), m_MaxPlnDist2Merge(maxPlnDist2Merge),
+                  m_MaxPlnAngle2Merge(maxPlnAngle2Merge), m_EPS(EPS)
+        {}
+
+        void OnSLAMCombineMap();
+
+    private:
+        // Combine Map Parameters
+        std::string m_MapPathA;
+        std::string m_MapPathB;
+        std::string m_OutputPath;
+        int m_OptimizeIterations;
+
+        // Reconstruction Parameters
+        float m_RadiusSearch;
+        double m_CreaseAngleThreshold;
+        int m_MinClusterSize;
+        double m_AABBScaleFactor;
+        double m_MaxPolyTagDist;
+        double m_MaxPlnDist2Merge;
+        double m_MaxPlnAngle2Merge;
+        double m_EPS;
+    };
 }

--- a/src/AIAC/LayerUI.cpp
+++ b/src/AIAC/LayerUI.cpp
@@ -1225,14 +1225,27 @@ namespace AIAC
             if(ImGui::Button("Cancel", ImVec2(80, 0))){ m_IsCombiningMap = false; }
             ImGui::SameLine();
             if(ImGui::Button("Confirm", ImVec2(80, 0))){
-                if(strlen(m_CombMapParams.MapPathA) == 0 || strlen(m_CombMapParams.MapPathB) == 0 || strlen(m_CombMapParams.OutputPath) == 0){
+                if(strlen(m_CombMapParams.MapPathA) == 0 || strlen(m_CombMapParams.MapPathB) == 0){
                     AIAC_ERROR("Path not selected.");
-
                 } else {
-                    AIAC_APP.GetLayer<LayerSlam>()->Slam.CombineMap(
-                            m_CombMapParams.MapPathA, m_CombMapParams.MapPathB, m_CombMapParams.OutputPath,
-                            true, true, nullptr, 2);
-                    memset(m_CombMapParams.MapPathA, 0, PATH_BUF_SIZE * 3);
+                    AIAC_EBUS->EnqueueEvent(std::make_shared<SLAMCombineMapEvent>(
+                            m_CombMapParams.MapPathA,
+                            m_CombMapParams.MapPathB,
+                            m_CombMapParams.OutputPath,
+                            50,
+                            m_ReconstructParams.RadiusSearch,
+                            m_ReconstructParams.CreaseAngleThreshold,
+                            m_ReconstructParams.MinClusterSize,
+                            m_ReconstructParams.AABBScaleFactor,
+                            m_ReconstructParams.MaxPolyDist,
+                            m_ReconstructParams.MaxPlnDist,
+                            m_ReconstructParams.MaxPlnAngle,
+                            m_ReconstructParams.Eps
+                    ));
+
+                    memset(m_CombMapParams.MapPathA, 0, PATH_BUF_SIZE);
+                    memset(m_CombMapParams.MapPathB, 0, PATH_BUF_SIZE);
+                    memset(m_CombMapParams.OutputPath, 0, PATH_BUF_SIZE);
                     m_IsCombiningMap = false;
                 }
             }


### PR DESCRIPTION
# Description 🤖
The combined map in the previous version has a problem in that some tags are missing. The reason is still unknown.
This hotfix directly invokes the compiled tslam utility `tslam_combime_map`, which should be installed in the system path.

When combining the map, select the two maps to be combined. The output path can be left blank. This will produce a new map named `{map_A}_combined_{map_B}` in `map A`'s path, with TSLAM map, tag info (.yml), and visualized map (.ply).

![image](https://github.com/user-attachments/assets/8e9c18af-f22d-4e10-bae9-be8253483340)

The TSLAM package should be updated and re-built to make it compatible with this change.

## Type of feature/changes 🌲
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update