### PR TITLE
Fix ghost points

### DIFF
--- a/src/AIAC/Render/GLObject.cpp
+++ b/src/AIAC/Render/GLObject.cpp
@@ -59,8 +59,8 @@ namespace AIAC
         BindVBOs();
         GLfloat prevPointSize;
         glGetFloatv(GL_POINT_SIZE, &prevPointSize);
-        glPointSize(pointSize);
-        glDrawArrays(GL_POINTS, 0, size);
+        glPointSize(this->pointSize);
+        glDrawArrays(GL_POINTS, 0, this->size);
         glPointSize(prevPointSize);
     }
 


### PR DESCRIPTION
# Description 🤖
Fix the ghost points that are rendered by mistake.
This is caused by a wrong array size assigned to OpenGL, leading to an out-of-bound access.

Fix #64 
Fix #56

## Type of feature/changes 🌲
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update